### PR TITLE
Standardize user ids to our user ids

### DIFF
--- a/app/src/main/java/com/example/watpool/services/firebase_services/FirebaseAuthService.kt
+++ b/app/src/main/java/com/example/watpool/services/firebase_services/FirebaseAuthService.kt
@@ -1,11 +1,13 @@
 package com.example.watpool.services.firebase_services
 
 import com.example.watpool.services.interfaces.AuthService
+import com.example.watpool.ui.profile.UserDetails
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.UserProfileChangeRequest
+import com.google.firebase.firestore.FirebaseFirestore
 
 class FirebaseAuthService : AuthService {
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
@@ -25,12 +27,7 @@ class FirebaseAuthService : AuthService {
         return user!!.updateProfile(profileUpdates)
     }
 
-    fun getCurrentUser(): FirebaseUser? {
+    override fun getCurrentUser(): FirebaseUser? {
         return auth.currentUser
-    }
-
-    override fun currentUser(): String {
-        val user =  auth.currentUser
-        return user?.uid ?: "Not signed in"
     }
 }

--- a/app/src/main/java/com/example/watpool/services/firebase_services/FirebaseUserService.kt
+++ b/app/src/main/java/com/example/watpool/services/firebase_services/FirebaseUserService.kt
@@ -25,7 +25,7 @@ class FirebaseUserService: UserService {
     override fun fetchUserByDocumentId(id: String): Task<DocumentSnapshot> {
         return usersRef.document(id).get()
     }
-    override fun fetchUsersByUsername(email: String): Task<QuerySnapshot> {
+    override fun fetchUsersByEmail(email: String): Task<QuerySnapshot> {
         return usersRef.whereEqualTo("email", email).get()
     }
 
@@ -70,4 +70,4 @@ class FirebaseUserService: UserService {
 
 
     
-    }
+}

--- a/app/src/main/java/com/example/watpool/services/interfaces/AuthService.kt
+++ b/app/src/main/java/com/example/watpool/services/interfaces/AuthService.kt
@@ -2,10 +2,11 @@ package com.example.watpool.services.interfaces
 
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseUser
 
 interface AuthService {
     fun signIn(email: String, password: String): Task<AuthResult>
     fun signUp(email: String, password: String): Task<AuthResult>
     fun updateUserProfile(name: String): Any
-    fun currentUser(): String
+    fun getCurrentUser(): FirebaseUser?
 }

--- a/app/src/main/java/com/example/watpool/services/interfaces/UserService.kt
+++ b/app/src/main/java/com/example/watpool/services/interfaces/UserService.kt
@@ -7,7 +7,7 @@ import com.google.firebase.firestore.QuerySnapshot
 interface UserService {
     fun fetchUsersById(id: String): Task<QuerySnapshot>
     fun fetchUserByDocumentId(id: String): Task<DocumentSnapshot>
-    fun fetchUsersByUsername(username: String): Task<QuerySnapshot>
+    fun fetchUsersByEmail(email: String): Task<QuerySnapshot>
     fun createUser(email: String, name: String): Task<DocumentReference>
     fun createDriver(username: String, licenseNumber: String, carModel: String, carColor: String ): Task<Void>
 }

--- a/app/src/main/java/com/example/watpool/ui/tripList/TripListFragment.kt
+++ b/app/src/main/java/com/example/watpool/ui/tripList/TripListFragment.kt
@@ -178,9 +178,7 @@ class TripListFragment : Fragment() {
 
             // Fetch trips once the service is connected
             firebaseService?.let {
-                //val riderId = it.currentUser()
-                val riderId = "user_id_1"
-                tripListViewModel.fetchConfirmedTrips(it, riderId)
+                tripListViewModel.fetchConfirmedTrips(it)
             }
         }
 

--- a/app/src/main/java/com/example/watpool/ui/tripList/TripListViewModel.kt
+++ b/app/src/main/java/com/example/watpool/ui/tripList/TripListViewModel.kt
@@ -13,9 +13,10 @@ class TripListViewModel : ViewModel() {
     private val _trips = MutableLiveData<List<TripConfirmationDetails>>()
     val trips: LiveData<List<TripConfirmationDetails>> get() = _trips
 
-    fun fetchConfirmedTrips(firebaseService: FirebaseService, riderId: String) {
+    fun fetchConfirmedTrips(firebaseService: FirebaseService) {
         viewModelScope.launch {
             try {
+                val riderId = firebaseService.currentUser()
                 val tripsList = firebaseService.fetchAllConfirmedTripsByRiderId(riderId)
                 _trips.value = tripsList
             } catch (e: Exception) {


### PR DESCRIPTION
There's a mismatch in the user ids we're using. Previously, currentUser() was returning the uid within firebase's oauth database. This id was being used for create trips, and list trips. However, we have additional info for our users, and this was retrieved using this query in the profile page.

Using inspiration from the query in the profile page, I changed currentUsers. We need this change in order to display driver or passenger info for trips.


```private val usersRef = FirebaseFirestore.getInstance().collection("users")

    init {
        val user = FirebaseAuth.getInstance().currentUser
        _userLiveData.value = user
        fetchUserDetails(user)
    }

    private fun fetchUserDetails(user: FirebaseUser?) {
        user?.let {
            fetchUsersByEmail(it.email ?: "").addOnSuccessListener { querySnapshot ->
                if (!querySnapshot.isEmpty) {
                    val document = querySnapshot.documents[0]
                    val userDetails = UserDetails(
                        email = document.getString("email") ?: "N/A",
                        isDriver = document.getBoolean("is_driver") ?: false,
                        name = document.getString("name") ?: "N/A",
                        ratingAsDriver = (document.getLong("rating_as_driver") ?: 0L).toInt(),
                        ratingAsRider = (document.getLong("rating_as_rider") ?: 0L).toInt()
                    )
                    _userDetails.value = userDetails
                }
            }
        }
    }```
